### PR TITLE
fix: add retry mechanism to fetch.js to handle rate limiting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,0 @@
-repos:
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v3.0.0-alpha.4" # Use the sha or tag you want to point at
-  hooks:
-    - id: prettier
-      files: ".*.(json|js|css)"
-
-

--- a/fetch.js
+++ b/fetch.js
@@ -34,9 +34,17 @@ async function fetchWithRetry(options, data, retries = 5, delay = 5000) {
               resolve(responseData);
             } else if (res.statusCode === 429 && i < retries - 1) {
               console.log(`Rate limited. Retrying in ${delay}ms...`);
-              setTimeout(() => resolve(fetchWithRetry(options, data, retries - 1, delay)), delay);
+              setTimeout(
+                () =>
+                  resolve(fetchWithRetry(options, data, retries - 1, delay)),
+                delay
+              );
             } else {
-              reject(new Error(`${options.path} request failed with status code: ${res.statusCode}`));
+              reject(
+                new Error(
+                  `${options.path} request failed with status code: ${res.statusCode}`
+                )
+              );
             }
           });
         });

--- a/fetch.js
+++ b/fetch.js
@@ -18,6 +18,48 @@ const ERR = {
     "The request to Medium didn't succeed. Check if Medium username in your .env file is correct."
 };
 
+async function fetchWithRetry(options, data, retries = 5, delay = 5000) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await new Promise((resolve, reject) => {
+        const req = https.request(options, res => {
+          let responseData = "";
+
+          res.on("data", d => {
+            responseData += d;
+          });
+
+          res.on("end", () => {
+            if (res.statusCode === 200) {
+              resolve(responseData);
+            } else if (res.statusCode === 429 && i < retries - 1) {
+              console.log(`Rate limited. Retrying in ${delay}ms...`);
+              setTimeout(() => resolve(fetchWithRetry(options, data, retries - 1, delay)), delay);
+            } else {
+              reject(new Error(`${options.path} request failed with status code: ${res.statusCode}`));
+            }
+          });
+        });
+
+        req.on("error", error => {
+          reject(error);
+        });
+
+        if (data) {
+          req.write(data);
+        }
+        req.end();
+      });
+    } catch (error) {
+      if (i === retries - 1) {
+        throw error;
+      }
+      console.log(`Error fetching data. Retrying in ${delay}ms...`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}
+
 if (USE_GITHUB_DATA === "true") {
   if (GITHUB_USERNAME === undefined) {
     throw new Error(ERR.noUserName);
@@ -69,31 +111,16 @@ if (USE_GITHUB_DATA === "true") {
     }
   };
 
-  const req = https.request(default_options, res => {
-    let data = "";
-
-    console.log(`statusCode: ${res.statusCode}`);
-    if (res.statusCode !== 200) {
-      throw new Error(ERR.requestFailed);
-    }
-
-    res.on("data", d => {
-      data += d;
-    });
-    res.on("end", () => {
-      fs.writeFile("./public/profile.json", data, function (err) {
+  fetchWithRetry(default_options, data)
+    .then(responseData => {
+      fs.writeFile("./public/profile.json", responseData, function (err) {
         if (err) return console.log(err);
         console.log("saved file to public/profile.json");
       });
+    })
+    .catch(error => {
+      console.error("Error:", error);
     });
-  });
-
-  req.on("error", error => {
-    throw error;
-  });
-
-  req.write(data);
-  req.end();
 }
 
 if (MEDIUM_USERNAME !== undefined) {
@@ -106,29 +133,22 @@ if (MEDIUM_USERNAME !== undefined) {
     method: "GET"
   };
 
-  const req = https.request(options, res => {
-    console.log(`statusCode: ${res.statusCode}`);
-    if (res.statusCode !== 200) {
-      throw new Error(ERR.requestMediumFailed);
-    }
+  fetchWithRetry(options)
+    .then(responseData => {
+      feed2json.fromString(responseData, url, {}, (err, json) => {
+        if (err) {
+          console.error("Error converting feed to JSON:", err);
+          return;
+        }
 
-    feed2json.fromStream(res, url, {}, (err, json) => {
-      if (err) {
-        console.error("Error converting feed to JSON:", err);
-        return;
-      }
-
-      const mediumData = JSON.stringify(json, null, 2);
-      fs.writeFile("./public/blogs.json", mediumData, function (err) {
-        if (err) return console.error(err);
-        console.log("Saved file to public/blogs.json");
+        const mediumData = JSON.stringify(json, null, 2);
+        fs.writeFile("./public/blogs.json", mediumData, function (err) {
+          if (err) return console.error(err);
+          console.log("Saved file to public/blogs.json");
+        });
       });
+    })
+    .catch(error => {
+      console.error("Error:", error);
     });
-  });
-
-  req.on("error", error => {
-    throw error;
-  });
-
-  req.end();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache/node_modules/yallist": {
+      "version": "3.1.1",
+      "license": "ISC"
+    },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
@@ -3659,6 +3670,59 @@
         }
       }
     },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "license": "MIT",
@@ -5602,6 +5666,10 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/camel-case/node_modules/tslib": {
+      "version": "2.6.1",
+      "license": "0BSD"
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "license": "MIT",
@@ -6914,6 +6982,10 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.6.1",
+      "license": "0BSD"
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -7810,7 +7882,7 @@
       "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "fast-deep-equal": "^3.1.3"
       },
       "engines": {
         "node": ">=10"
@@ -8299,7 +8371,7 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/finalhandler/node_modules/ms": {
+    "node_modules/finalhandler/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
@@ -9442,6 +9514,19 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11168,11 +11253,18 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.6.1",
+      "license": "0BSD"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/magic-string": {
@@ -11875,6 +11967,10 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/param-case/node_modules/tslib": {
+      "version": "2.6.1",
+      "license": "0BSD"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -11946,6 +12042,10 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/pascal-case/node_modules/tslib": {
+      "version": "2.6.1",
+      "license": "0BSD"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -12161,6 +12261,13 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13945,12 +14052,28 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/readdirp": {
@@ -14652,6 +14775,13 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
       }
     },
     "node_modules/scriptjs": {


### PR DESCRIPTION
# Description

This PR introduces a retry mechanism to the `fetch.js` script to handle rate limiting errors (HTTP 429) when fetching data from the GitHub and Medium APIs. This ensures that the script can recover gracefully from transient errors and reduces the likelihood of build failures due to API rate limits. Additionally, improved error handling and logging have been added to provide better visibility into retry attempts and errors.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

